### PR TITLE
Add Rust hello-no-std example

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -1,0 +1,9 @@
+.PHONY: all clean
+
+all: hello-no-std
+
+hello-no-std: hello-no-std.rs
+	rustc --target x86_64-unknown-none $<
+
+clean:
+	-rm -f hello-no-std

--- a/lang/rust/hello-no-std.rs
+++ b/lang/rust/hello-no-std.rs
@@ -1,0 +1,54 @@
+#![no_std]
+#![no_main]
+
+use core::{arch::asm, convert::TryInto};
+
+unsafe fn syscall_1(num: u64, arg1: u64) -> i64 {
+    let res;
+    asm!(
+        "syscall",
+        in("rax") num,
+        in("rdi") arg1,
+        lateout("rax") res,
+    );
+    res
+}
+
+unsafe fn syscall_3(num: u64, arg1: u64, arg2: u64, arg3: u64) -> i64 {
+    let res;
+    asm!(
+        "syscall",
+        in("rax") num,
+        in("rdi") arg1,
+        in("rsi") arg2,
+        in("rdx") arg3,
+        lateout("rax") res,
+    );
+    res
+}
+
+fn sys_exit(code: i32) -> ! {
+    unsafe {
+        syscall_1(60, code as _);
+    }
+    unreachable!();
+}
+
+unsafe fn sys_write(fd: u64, data: *const u8, len: u64) -> i64 {
+    syscall_3(1, fd, data as u64, len)
+}
+
+fn print(data: &[u8]) -> i64 {
+    unsafe { sys_write(1, data.as_ptr(), data.len().try_into().unwrap()) }
+}
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    print(b"Hello no_std!\n");
+    sys_exit(0);
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}


### PR DESCRIPTION
Closes https://github.com/unikraft/static-pie-apps/pull/3.

This example builds a freestanding Rust application which manually performs Linux syscalls.

This requires `rust-std` (only `core` though) for `x86_64-unknown-none`. Those binaries are not yet available on stable.

You can default to nightly and install the binaries like this:
```
$ rustup install nightly
$ rustup default nightly
$ rustup target install x86_64-unknown-none
```