### PR TITLE
add build from source script; gitignore and small README

### DIFF
--- a/traefik/.gitignore
+++ b/traefik/.gitignore
@@ -1,0 +1,1 @@
+traefik*

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -1,0 +1,11 @@
+# Build Script
+
+This build script downloads the latest version of traefik form the
+corresponding github releases page. To modify the installation version change
+the `version` variable in the `build.sh`.
+
+# Requirements
+
+*Not installed by the build script.*
+
+* golang: 1.20.6

--- a/traefik/build.sh
+++ b/traefik/build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+version=v2.10.3
+name=traefik
+appname=${name}-${version}
+tarball=${appname}.src.tar.gz
+
+echo "Cleaning artefacts ..."
+rm -rf ${tarball} ${appname} ${name}
+
+echo -n "Downloading ${tarball} ... "
+wget -q https://github.com/traefik/traefik/releases/download/${version}/${tarball}
+echo ""
+
+echo -n "Unpacking traefik ... "
+mkdir -p ./$appname
+tar xzf $tarball -C ./$appname
+echo ""
+
+echo -n "Setting up GO env ... "
+export GOPATH=~/go
+export PATH=$PATH:$GOPATH/bin
+echo ""
+
+#echo -n "Building traefik ... "
+#make clean-webui -C ${appname}
+#echo ""
+
+pushd ${appname}
+
+echo "${appname}: Running GO get ..."
+go get &&
+go mod tidy &&
+go generate &&
+go build -buildmode=pie \
+    -ldflags "-linkmode 'external' -extldflags '-static-pie'" \
+    -tags netgo \
+    ./cmd/traefik
+
+popd +0
+
+if test -f ${appname}/${name}; then
+    ln -s ${appname}/${name} ./${name}
+fi


### PR DESCRIPTION
Build a static pie ELF.

Does not run with run-app-elfoader.

A similar problem arises as with the [dynamic PR](https://github.com/unikraft/dynamic-apps/pull/54):
![image](https://github.com/unikraft/static-pie-apps/assets/45227026/e4dc3a8e-5e83-4912-8fac-0b5303087c37)
